### PR TITLE
Fixed crash on dealoc if view had not been loaded

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -523,7 +523,9 @@
     
     [self.wkWebView setNavigationDelegate:nil];
     [self.wkWebView setUIDelegate:nil];
-    [self.wkWebView removeObserver:self forKeyPath:@"estimatedProgress"];
+	if ([self isViewLoaded]) {
+		[self.wkWebView removeObserver:self forKeyPath:@"estimatedProgress"];
+	}
 }
 
 


### PR DESCRIPTION
Hi,

Thank you for creating a great library.

I just found a little bug that caused a crash if someone creates a view controller, but never load the view (in my case an instance of KINWebBrowserViewController is created, but never added to a super view because user back out too soon).

Please see changes below for details.

Minh
