### PR TITLE
Fix crash when action button is pressed and page has failed to load

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -452,6 +452,10 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
         URLForActivityItem = self.uiWebView.request.URL;
         URLTitle = [self.uiWebView stringByEvaluatingJavaScriptFromString:@"document.title"];
     }
+    if (!URLForActivityItem) {
+        // This happens if the webpage doesn't get loaded due to a connection issue
+        return;
+    }
     dispatch_async(dispatch_get_main_queue(), ^{
         TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
         ARChromeActivity *chromeActivity = [[ARChromeActivity alloc] init];


### PR DESCRIPTION
I have a crash with the exact stack trace from: https://github.com/dfmuir/KINWebBrowser/issues/11

Steps to reproduce: Fire up an app in the simulator with 1 button to push a KINWebBrowser instance with any URL you like. Turn wifi on computer off and push the button. KINWebBrowser ends up showing an empty screen. Press the sharing button => crash

At least in my case KINWebBrowser loads a wkwebview and the URL property ends up being nil when the page fails to load. When we try to construct an array as follows: "@[URLForActivityItem]" we get a crash. For now I'm handling by simply refusing the action, don't know if there's a better way to do it.