### PR TITLE
Show button images in iOS8

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -382,10 +382,11 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
 }
 
 - (void)setupToolbarItems {
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
     self.refreshButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(refreshButtonPressed:)];
     self.stopButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:self action:@selector(stopButtonPressed:)];
-    self.backButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"backbutton"] style:UIBarButtonItemStylePlain target:self action:@selector(backButtonPressed:)];
-    self.forwardButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"forwardbutton"] style:UIBarButtonItemStylePlain target:self action:@selector(forwardButtonPressed:)];
+    self.backButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageWithContentsOfFile:[bundle pathForResource:@"backbutton" ofType:@"png"]] style:UIBarButtonItemStylePlain target:self action:@selector(backButtonPressed:)];
+    self.forwardButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageWithContentsOfFile:[bundle pathForResource:@"forwardbutton" ofType:@"png"]] style:UIBarButtonItemStylePlain target:self action:@selector(forwardButtonPressed:)];
     self.actionButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionButtonPressed:)];
     self.fixedSeparator = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     self.fixedSeparator.width = 50.0f;


### PR DESCRIPTION
When using iOS8 project, browser's bottom-left button images are now shown. I fixed in this pull request.

Thanks for good library!

## Current

<img width="393" alt="current" src="https://cloud.githubusercontent.com/assets/536954/8704544/93d65fa2-2b5e-11e5-8d46-197410c79f4e.png">

## Fixed

<img width="393" alt="fixed" src="https://cloud.githubusercontent.com/assets/536954/8704549/987423e6-2b5e-11e5-8962-b2ae606b1acb.png">

<img width="393" alt="fixed2" src="https://cloud.githubusercontent.com/assets/536954/8704552/9bc9129a-2b5e-11e5-9415-28a5b1000905.png">

