### PR TITLE
supported interface orientations returns UIInterfaceOrientationMask i…

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -596,7 +596,7 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
 
 #pragma mark - Interface Orientation
 
-- (NSUInteger)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 


### PR DESCRIPTION
…nstead of NSUInteger to eliminate Xcode warnings
![screen shot 2015-09-09 at 21 29 57](https://cloud.githubusercontent.com/assets/11032592/9772010/f2d357ce-5739-11e5-986c-8a548ad37164.png)

I have this issue in a swift project using cocoa pods in Xcode 7 supporting an iOS 9 app