### PR TITLE
Fix Bug

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.h
+++ b/KINWebBrowser/KINWebBrowserViewController.h
@@ -64,7 +64,7 @@
  For convenience, two sets of static initializers are available.
  
  */
-@interface KINWebBrowserViewController : UIViewController <WKNavigationDelegate, UIWebViewDelegate>
+@interface KINWebBrowserViewController : UIViewController <WKNavigationDelegate, WKUIDelegate, UIWebViewDelegate>
 
 #pragma mark - Public Properties
 

--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -125,6 +125,7 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
         [self.wkWebView setFrame:self.view.bounds];
         [self.wkWebView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
         [self.wkWebView setNavigationDelegate:self];
+        [self.wkWebView setUIDelegate:self];
         [self.wkWebView setMultipleTouchEnabled:YES];
         [self.wkWebView setAutoresizesSubviews:YES];
         [self.wkWebView.scrollView setAlwaysBounceVertical:YES];
@@ -332,6 +333,14 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
         }
     }
     decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+#pragma mark - WKUIDelegate
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures{
+    if (!navigationAction.targetFrame.isMainFrame) {
+        [webView loadRequest:navigationAction.request];
+    }
+    return nil;
 }
 
 #pragma mark - Toolbar State


### PR DESCRIPTION
Web browser can’t open the link which have target=‘_blank’ attribute in HTML code

See http://stackoverflow.com/questions/25713069/why-is-wkwebview-not-opening-links-with-target-blank