### PR TITLE
Add support for custom share items

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.h
+++ b/KINWebBrowser/KINWebBrowserViewController.h
@@ -112,8 +112,20 @@
 @property (nonatomic, assign) BOOL showsURLInNavigationBar;
 @property (nonatomic, assign) BOOL showsPageTitleInNavigationBar;
 
-//Allow for custom activities in the browser by populating this optional array
+/*
+ Allow for custom activities in the browser by populating this optional array
+ 
+ Warning: Custom activities is actualy not the right name for this property.
+ This array will be used as applicationActivities in UIActivityViewController's initWithActivityItems:applicationActivities:, not as activityItems as the name suggests.
+ It should be renamed to something like customApplicationActivities, but this would be a breaking change.
+ */
 @property (nonatomic, strong) NSArray *customActivityItems;
+
+/*
+ Allow for custom share items in the browser by populating this optional array
+ It will be used as activityItems in UIActivityViewController's initWithActivityItems:applicationActivities:
+ */
+@property (nonatomic, strong) NSArray *customShareItems;
 
 #pragma mark - Public Interface
 

--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -481,8 +481,13 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
         URLForActivityItem = self.uiWebView.request.URL;
         URLTitle = [self.uiWebView stringByEvaluatingJavaScriptFromString:@"document.title"];
     }
-    if (URLForActivityItem) {
+    if (URLForActivityItem || self.customShareItems) {
         dispatch_async(dispatch_get_main_queue(), ^{
+            NSArray *shareItems = @[URLForActivityItem];
+            if (self.customShareItems) {
+                shareItems = self.customShareItems;
+            }
+            
             TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
             ARChromeActivity *chromeActivity = [[ARChromeActivity alloc] init];
             
@@ -493,7 +498,7 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
                 [activities addObjectsFromArray:self.customActivityItems];
             }
             
-            UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[URLForActivityItem] applicationActivities:activities];
+            UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:shareItems applicationActivities:activities];
             
             if([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
                 if(self.actionPopoverController) {


### PR DESCRIPTION
… and warn about the impoperly named customActivityItems property.

As mentioned here: https://github.com/dfmuir/KINWebBrowser/issues/44