### PR TITLE
Make TUSafariActivity and ARChromeActivity optional

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -32,8 +32,12 @@
 
 #import "KINWebBrowserViewController.h"
 
-#import "TUSafariActivity.h"
-#import "ARChromeActivity.h"
+#if __has_include("TUSafariActivity.h")
+    #import "TUSafariActivity.h"
+#endif
+#if __has_include("ARChromeActivity.h")
+    #import "ARChromeActivity.h"
+#endif
 
 static void *KINWebBrowserContext = &KINWebBrowserContext;
 
@@ -483,12 +487,19 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
     }
     if (URLForActivityItem) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
-            ARChromeActivity *chromeActivity = [[ARChromeActivity alloc] init];
-            
             NSMutableArray *activities = [[NSMutableArray alloc] init];
-            [activities addObject:safariActivity];
-            [activities addObject:chromeActivity];
+
+            Class TUSafariActivityClass = NSClassFromString(@"TUSafariActivity");
+            if (TUSafariActivityClass) {
+                id safariActivity = [[TUSafariActivityClass alloc] init];
+                [activities addObject:safariActivity];
+            }
+            Class ARChromeActivityClass = NSClassFromString(@"ARChromeActivity");
+            if (ARChromeActivityClass) {
+                id chromeActivity = [[ARChromeActivityClass alloc] init];
+                [activities addObject:chromeActivity];
+            }
+
             if(self.customActivityItems != nil) {
                 [activities addObjectsFromArray:self.customActivityItems];
             }


### PR DESCRIPTION
Conditionally importing and using `TUSafariActivity` and `ARChromeActivity`, so they are no longer hard project dependencies.

This allows the repository to easily be used outside of CocoaPods (for example, as a git submodule). It's also a fix/workaround for #16.