### PR TITLE
Use [KINWebBrowserViewController class] instead of [self class].

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -405,7 +405,7 @@ static void *KINWebBrowserContext = &KINWebBrowserContext;
 }
 
 - (void)setupToolbarItems {
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *bundle = [NSBundle bundleForClass:[KINWebBrowserViewController class]];
     
     self.refreshButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(refreshButtonPressed:)];
     self.stopButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:self action:@selector(stopButtonPressed:)];


### PR DESCRIPTION
Using [KINWebBrowserViewController class] instead of [self class] allows to retrieve back/forward images correctly when subclassing KINWebBrowserViewController.
If you subclass KINWebBrowserViewController (including it in your application using CocoaPods with framework) the path to the image resource could be wrong. This fixes the problem.
